### PR TITLE
feat: Implement OAuth device code flow for headless environments

### DIFF
--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -7,6 +7,11 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
     - Use this option to log in with your google account.
     - During initial startup, Gemini CLI will direct you to a webpage for authentication. Once authenticated, your credentials will be cached locally so the web login can be skipped on subsequent runs.
     - Note that the web login must be done in a browser that can communicate with the machine Gemini CLI is being run from. (Specifically, the browser will be redirected to a localhost url that Gemini CLI will be listening on).
+    - **Using Device Code Flow (for headless environments):** If you are running Gemini CLI in an environment without a browser (e.g., a remote server or Codespaces), you can use the device code flow. To enable this, set the `GEMINI_AUTH_MODE` environment variable to `device`:
+      ```bash
+      export GEMINI_AUTH_MODE="device"
+      ```
+      When you run the CLI, it will display a URL and a code. You'll need to open this URL in a browser on another device (like your laptop or phone) and enter the code to authorize the CLI.
     - <a id="workspace-gca">Users may have to specify a GOOGLE_CLOUD_PROJECT if:</a>
       1. You have a Google Workspace account. Google Workspace is a paid service for businesses and organizations that provides a suite of productivity tools, including a custom email domain (e.g. your-name@your-company.com), enhanced security features, and administrative controls. These accounts are often managed by an employer or school.
       2. You are a licensed Code Assist user. This can happen if you have previously purchased a Code Assist license or have acquired one through Google Developer Program.


### PR DESCRIPTION
This change introduces an OAuth device code flow to allow users to authenticate in environments without a browser, such as remote servers or Codespaces.

Key changes:
- Added `authWithDeviceCode` function in `packages/core/src/code_assist/oauth2.ts` to handle the device code grant.
- Modified `getOauthClient` to accept a `useDeviceCodeFlow` parameter.
- Updated `packages/cli/src/gemini.tsx` to check for the `GEMINI_AUTH_MODE=device` environment variable to trigger the device flow.
- Updated `docs/cli/authentication.md` with instructions for the new flow.
- Added unit tests for the device code flow logic.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
